### PR TITLE
issue #10 upgrading ala-auth plugin to latest available relase versio…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,11 +102,11 @@ dependencies {
     runtimeOnly 'org.codehaus.groovy:groovy-dateutil'
 
     // grails plugins
-    implementation "org.grails.plugins:ala-auth:5.1.0"
+    implementation "org.grails.plugins:ala-auth:$alaSecurityLibsVersion"
 //    compile "org.grails.plugins:ala-admin-plugin:2.3.0"
     implementation "org.grails.plugins:ala-bootstrap3:4.1.0"
 
-    implementation 'dk.glasius:external-config:3.0.1'
+    implementation 'dk.glasius:external-config:3.1.1'
 
     // HA
     implementation 'org.springframework.session:spring-session-data-mongodb'

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,4 @@ gorm.version=7.3.2
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx1024M
+alaSecurityLibsVersion=6.0.4


### PR DESCRIPTION
…n, using alaSecurityLibsVersion for auth plugin version specification, upgrading external-config to 3.1.1

- [x] TODO  - upgrade to a newer version of auth plugin when available before merge